### PR TITLE
Fix Reference to display project reference number

### DIFF
--- a/source/php/Controller.php
+++ b/source/php/Controller.php
@@ -43,6 +43,7 @@ class Controller
       $data['startDate'] = $this->getMeta('publish_start_date'); 
       $data['endDate'] = $this->getMeta('publish_end_date'); 
       $data['referenceId'] = $this->getMeta('ad_reference_nbr');
+      $data['projectNr'] = $this->getMeta('uuid');
       $data['numberOfPositions'] = $this->getMeta('number_of_positions'); 
       $data['expreience'] = $this->getMeta('number_of_positions'); 
       $data['employmentType'] = $this->getMeta('employment_type'); 
@@ -62,7 +63,7 @@ class Controller
      * @return mixed
      */
     public function getMeta($key, $single = true) {
-      return get_post_meta($this->post->ID, $key, $single); 
+      return get_post_meta($this->post->ID, $key, $single);
     } 
 
     /**

--- a/source/php/Cron/ReachmeeImport.php
+++ b/source/php/Cron/ReachmeeImport.php
@@ -225,7 +225,7 @@ class ReachmeeImport extends Import
             'employment_end_date' => array("pubDateTo"),
             'ad_created' => array("pubDate"),
             'ad_modified' => array("pubDate"),
-            'ad_reference_nbr' => array("projectName"),
+            'ad_reference_nbr'=> array("projectName"),
             //'number_of_positions' => "1",
             'external_url' => array("link"),
             'is_internal' => array("hideApplyButton"),

--- a/views/single-job-listing.blade.php
+++ b/views/single-job-listing.blade.php
@@ -100,12 +100,11 @@
                                     </li>
                                 @endif
 
-                                @if($referenceId)
+                                @if($projectNr)
                                     <li class="gutter gutter-top">
                                         <b><?php _e('Reference:', 'job-listings'); ?></b>
                                         <br/>
-                                        {{ $referenceId }}
-                                    </li>
+                                        {{ $projectNr }}                                     </li>
                                 @endif
 
                                 @if($startDate)


### PR DESCRIPTION
The reference field in the right column was displaying the job title rather than the reference number created by ReachMee. This just fixes that; it reads the id from the XML-file and displays it in the singe job view.